### PR TITLE
Propagate flowchart option to build graphs forward from dependencies to targets

### DIFF
--- a/makefile2dot/__init__.py
+++ b/makefile2dot/__init__.py
@@ -32,7 +32,10 @@ def build_graph(stream, **kwargs):
     """
     Build a dependency graph from the Makefile database.
     """
-
+    flowchart = kwargs.get('flowchart', False)
+    direction = kwargs.get('direction', 'TB')
+    print(f'{flowchart=}')
+    print(f'{direction=}')
     graph = gv.Digraph(comment="Makefile")
     graph.attr(rankdir=kwargs.get('direction', 'TB'))
     for line in stream:
@@ -51,7 +54,10 @@ def build_graph(stream, **kwargs):
                 graph.node(dependency, shape="rectangle")
             else:
                 graph.node(dependency, shape="rectangle")
-                graph.edge(target, dependency)
+                if flowchart:
+                    graph.edge(dependency, target)
+                else:
+                    graph.edge(target, dependency)
 
     return graph
 
@@ -68,7 +74,7 @@ def makefile2dot(**kwargs):
     output = kwargs.get('output', '')
     view = kwargs.get('view', False)
 
-    graph = build_graph(stream_database(), direction=direction)
+    graph = build_graph(stream_database(), **kwargs)
     if output == "":
         if view:
             graph.view()

--- a/makefile2dot/__init__.py
+++ b/makefile2dot/__init__.py
@@ -34,10 +34,8 @@ def build_graph(stream, **kwargs):
     """
     flowchart = kwargs.get('flowchart', False)
     direction = kwargs.get('direction', 'TB')
-    print(f'{flowchart=}')
-    print(f'{direction=}')
     graph = gv.Digraph(comment="Makefile")
-    graph.attr(rankdir=kwargs.get('direction', 'TB'))
+    graph.attr(rankdir=direction)
     for line in stream:
         target, dependencies = line.split(':')
 

--- a/makefile2dot/__init__.py
+++ b/makefile2dot/__init__.py
@@ -28,14 +28,13 @@ def stream_database():
             yield line.strip()
 
 
-def build_graph(stream, **kwargs):
+def build_graph(stream, direction, flowchart):
     """
     Build a dependency graph from the Makefile database.
     """
-    flowchart = kwargs.get('flowchart', False)
-    direction = kwargs.get('direction', 'TB')
+
     graph = gv.Digraph(comment="Makefile")
-    graph.attr(rankdir=direction)
+    graph.attr(rankdir=direction) 
     for line in stream:
         target, dependencies = line.split(':')
 
@@ -60,19 +59,16 @@ def build_graph(stream, **kwargs):
     return graph
 
 
-def makefile2dot(**kwargs):
+def makefile2dot(direction, output, view, flowchart):
     """
     Visualize a Makefile as a Graphviz graph.
     """
-
-    direction = kwargs.get('direction', "BT")
+    if flowchart and (direction=="BT"):
+        direction = "TB"
     if direction not in ["LR", "RL", "BT", "TB"]:
         raise ValueError('direction must be one of "BT", "TB", "LR", RL"')
 
-    output = kwargs.get('output', '')
-    view = kwargs.get('view', False)
-
-    graph = build_graph(stream_database(), **kwargs)
+    graph = build_graph(stream_database(), direction=direction, flowchart=flowchart)
     if output == "":
         if view:
             graph.view()

--- a/makefile2dot/test_makefile2dot.py
+++ b/makefile2dot/test_makefile2dot.py
@@ -12,7 +12,7 @@ def test_makefile():
     '''
     with io.StringIO() as output:
         with redirect_stdout(output):
-            makefile2dot(direction="TB")
+            makefile2dot(direction="TB", output="", view=False, flowchart=False)
         result = output.getvalue()
 
     assert "digraph {" in result

--- a/scripts/makefile2dot
+++ b/scripts/makefile2dot
@@ -15,10 +15,10 @@ PARSER.add_argument('--direction', '-d', dest='direction', default="BT",
 PARSER.add_argument('--output', '-o', dest='output', default="",
                     help="output file name (default: stdout).")
 
-PARSER.add_argument('--view', '-v', action='store_true',
+PARSER.add_argument('--view', '-v', action='store_true', default=False,
                     help="view the graph (disables output to stdout)")
 
-PARSER.add_argument('--flowchart', '-f', action='store_true',
+PARSER.add_argument('--flowchart', '-f', action='store_true', default=False,
                     help="Flowchart: arrows point Forward from dependencies to targets.")
 
 ARGS = PARSER.parse_args()

--- a/scripts/makefile2dot
+++ b/scripts/makefile2dot
@@ -18,6 +18,9 @@ PARSER.add_argument('--output', '-o', dest='output', default="",
 PARSER.add_argument('--view', '-v', action='store_true',
                     help="view the graph (disables output to stdout)")
 
+PARSER.add_argument('--flowchart', '-f', action='store_true',
+                    help="Flowchart: arrows point Forward from dependencies to targets.")
+
 ARGS = PARSER.parse_args()
 
-makefile2dot(direction=ARGS.direction, output=ARGS.output, view=ARGS.view)
+makefile2dot(direction=ARGS.direction, output=ARGS.output, view=ARGS.view, flowchart=ARGS.flowchart)


### PR DESCRIPTION
* Add defaults to parser arguments
* Add flowchart parser option
* makefile2dot() function now takes named arguments from parser
* makefile2dot() handles TB direction for flowchart option
* build_graph() draws edges depending on whether flowchart option is set to True
* Using kwargs.get() to set args defaults removed
* Args defaults now defined from the argparser